### PR TITLE
Fix env validation for tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -56,6 +56,9 @@ export default defineConfig({
       NODE_ENV: "test",
       ENABLE_TEST_AUTH: "true",
       AUTH_SECRET: process.env.AUTH_SECRET || randomBytes(32).toString("hex"),
+      DATABASE_URL:
+        process.env.DATABASE_URL ||
+        "postgresql://postgres:password@localhost:5432/albeorla-ts-starter",
     },
   },
 });

--- a/src/env.js
+++ b/src/env.js
@@ -11,8 +11,14 @@ export const env = createEnv({
       process.env.NODE_ENV === "production"
         ? z.string()
         : z.string().optional(),
-    AUTH_DISCORD_ID: z.string(),
-    AUTH_DISCORD_SECRET: z.string(),
+    AUTH_DISCORD_ID:
+      process.env.NODE_ENV === "production"
+        ? z.string()
+        : z.string().optional(),
+    AUTH_DISCORD_SECRET:
+      process.env.NODE_ENV === "production"
+        ? z.string()
+        : z.string().optional(),
     DATABASE_URL: z.string().url(),
     NODE_ENV: z
       .enum(["development", "test", "production"])


### PR DESCRIPTION
## Summary
- relax auth env requirement for non-production
- add default database URL for test server

## Testing
- `yarn playwright install --with-deps`
- `yarn test:e2e:ci` *(fails: Database is not available)*

------
https://chatgpt.com/codex/tasks/task_e_688956103918832295c4ad526f4f500e