### PR TITLE
chore: consolidate prettier config

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,9 @@
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.27.0"
   },
+  "prettier": {
+    "plugins": ["prettier-plugin-tailwindcss"]
+  },
   "ct3aMetadata": {
     "initVersion": "7.39.3"
   },

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,0 @@
-/** @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions} */
-export default {
-  plugins: ["prettier-plugin-tailwindcss"],
-};


### PR DESCRIPTION
## Summary
- inline prettier config into package.json
- remove standalone prettier.config.js

## Testing
- `yarn format:check`
- `AUTH_SECRET=foo AUTH_DISCORD_ID=foo AUTH_DISCORD_SECRET=foo DATABASE_URL=postgres://localhost:5432/foo yarn lint`
- `AUTH_SECRET=foo AUTH_DISCORD_ID=foo AUTH_DISCORD_SECRET=foo DATABASE_URL=postgres://localhost:5432/foo ENABLE_TEST_AUTH=true VERBOSE_TEST_LOGS=true yarn typecheck` *(fails: Property 'ENABLE_TEST_AUTH' does not exist on type)*
- `yarn test:e2e:ci` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_689134f0ae908322bc2621dfc495039f